### PR TITLE
RestSharp still calls the callback if etcd times out.

### DIFF
--- a/etcetera.specs/CanWatchKeys.cs
+++ b/etcetera.specs/CanWatchKeys.cs
@@ -1,4 +1,6 @@
-﻿namespace etcetera.specs
+﻿using System.Diagnostics;
+
+namespace etcetera.specs
 {
     using System.Threading;
     using Should;
@@ -14,7 +16,7 @@
         {
             _wasHit = new ManualResetEvent(false);
             Client.Set(AKey, "wassup");
-            
+
             Client.Watch(AKey, resp =>
             {
                 _wasHit.Set();
@@ -30,16 +32,16 @@
             _wasHit = new ManualResetEvent(false);
             Client.Set(AKey, "wassup");
 
+            var watch = new Stopwatch();
+            watch.Start();
             Client.Watch(AKey, resp =>
             {
+                watch.Stop();
                 _wasHit.Set();
             }, timeout: 1);
 
-            Thread.Sleep(1100);
-
-            Client.Set(AKey, "nope");
-
-            _wasHit.WaitOne(200).ShouldBeFalse();
+            _wasHit.WaitOne(200).ShouldBeTrue();
+            watch.ElapsedMilliseconds.ShouldBeLessThan(100);
         }
     }
 }


### PR DESCRIPTION
RestSharp still calls the callback if etcd times out. 
This test was failing for me with a single local etcd node running.
Don't particularly like this version of the test either.
