### PR TITLE
Added support for prevExist on CreateDir

### DIFF
--- a/etcetera.specs/CanUpdateDirsWithTtl.cs
+++ b/etcetera.specs/CanUpdateDirsWithTtl.cs
@@ -1,0 +1,76 @@
+﻿namespace etcetera.specs
+{
+    using System;
+    using Should;
+    using Xunit;
+
+    public class CanUpdateDirsWithTtl :
+        EtcdBase
+    {
+        EtcdResponse _response;
+        int _ttl = 30;
+        DateTime _now;
+
+        public CanUpdateDirsWithTtl()
+        {
+            Client.CreateDir(AKey);
+            _response = Client.CreateDir(AKey, _ttl, true);
+            _now = DateTime.Now;
+        }
+
+        [Fact]
+        public void ActionIsUpdate()
+        {
+            _response.Action.ShouldEqual("update");
+        }
+
+        [Fact]
+        public void KeyIsSet()
+        {
+            _response.Node.Key.ShouldEqual("/" + AKey);
+        }
+
+        [Fact]
+        public void TtlIsSet()
+        {
+            _response.Node.Ttl.ShouldEqual(_ttl);
+        }
+
+        [Fact]
+        public void IsDir()
+        {
+            _response.Node.Dir.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExpirationIsSet()
+        {
+            _response.Node.Expiration.ShouldBeGreaterThan(_now.AddSeconds(_ttl).AddSeconds(-1));
+            _response.Node.Expiration.ShouldBeLessThan(_now.AddSeconds(_ttl).AddSeconds(1));
+        }
+
+        [Fact]
+        public void PrevKeyIsSet()
+        {
+            _response.PrevNode.Key.ShouldEqual("/" + AKey);
+        }
+
+        [Fact]
+        public void PrevTtlIsNotSet()
+        {
+            _response.PrevNode.Ttl.ShouldBeNull();
+        }
+
+        [Fact]
+        public void PrevIsDir()
+        {
+            _response.PrevNode.Dir.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void PrevExpirationIsNotSet()
+        {
+            _response.PrevNode.Expiration.ShouldBeNull();
+        }
+    }
+}

--- a/etcetera.specs/etcetera.specs.csproj
+++ b/etcetera.specs/etcetera.specs.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CanSetDirsWithTtl.cs" />
     <Compile Include="CanSetKeysWithTtl.cs" />
     <Compile Include="CanSetKeys.cs" />
+    <Compile Include="CanUpdateDirsWithTtl.cs" />
     <Compile Include="CanWatchFromIndex.cs" />
     <Compile Include="CanWatchKeys.cs" />
     <Compile Include="CanWatchKeysRecursively.cs" />

--- a/etcetera/EtcdClient.cs
+++ b/etcetera/EtcdClient.cs
@@ -29,7 +29,7 @@
         /// <param name="key">a hierarchical key</param>
         /// <param name="ttl">time to live in seconds</param>
         /// <param name="value">etcd only supports string values</param>
-        /// <param name="prevExist">Used to compare and swap on existance</param>
+        /// <param name="prevExist">Used to compare and swap on existence</param>
         /// <param name="prevValue">Used to compare and swap on value</param>
         /// <param name="prevIndex">Used to compare and swap on index</param>
         /// <returns></returns>
@@ -65,8 +65,9 @@
         /// </summary>
         /// <param name="key">the directory key</param>
         /// <param name="ttl">time to live in seconds</param>
+        /// <param name="prevExist">Used to compare and swap on existence</param>
         /// <returns></returns>
-        public EtcdResponse CreateDir(string key, int ttl = 0)
+        public EtcdResponse CreateDir(string key, int ttl = 0, bool? prevExist = null)
         {
             return makeKeyRequest(key, Method.PUT, req =>
             {
@@ -74,6 +75,10 @@
                 if (ttl > 0)
                 {
                     req.AddParameter("ttl", ttl);
+                }
+                if (prevExist.HasValue)
+                {
+                    req.AddParameter("prevExist", prevExist.Value.ToString().ToLower());
                 }
             });
         }

--- a/etcetera/IEtcdClient.cs
+++ b/etcetera/IEtcdClient.cs
@@ -12,7 +12,7 @@
         /// <param name="key">a hierarchical key</param>
         /// <param name="ttl">time to live in seconds</param>
         /// <param name="value">etcd only supports string values</param>
-        /// <param name="prevExist">Used to compare and swap on existance</param>
+        /// <param name="prevExist">Used to compare and swap on existence</param>
         /// <param name="prevValue">Used to compare and swap on value</param>
         /// <param name="prevIndex">Used to compare and swap on index</param>
         /// <returns></returns>
@@ -25,8 +25,9 @@
         /// </summary>
         /// <param name="key">the directory key</param>
         /// <param name="ttl">time to live in seconds</param>
+        /// <param name="prevExist">Used to compare and swap on existence</param>
         /// <returns></returns>
-        EtcdResponse CreateDir(string key, int ttl = 0);
+        EtcdResponse CreateDir(string key, int ttl = 0, bool? prevExist = null);
 
 
         /// <summary>


### PR DESCRIPTION
It is supported with a CanUpdateDirsWithTtl test to ensure that a TTL can be added to (or modified on) an existing directory.
