### PR TITLE
Change Watch Timeout to Seconds

### DIFF
--- a/etcetera/EtcdClient.cs
+++ b/etcetera/EtcdClient.cs
@@ -176,7 +176,7 @@
 
             if (timeout.HasValue)
             {
-                getRequest.Timeout = timeout.Value;
+                getRequest.Timeout = timeout.Value * 1000;
             }
 
             if (waitIndex.HasValue)
@@ -234,7 +234,7 @@
             return response.StatusCode == 0;
         }
 
-         Exception constructException(IRestResponse<EtcdResponse> response)
+        Exception constructException(IRestResponse<EtcdResponse> response)
         {
             var msg = new StringBuilder();
             msg.AppendFormat("Server: '{0}'", _client.BaseUrl);


### PR DESCRIPTION
Hi Dru, 

Awesome library - thank you for taking the time to make it!

I thought it would be a good idea to have all the Etcd client calls in seconds (ie: ttl, timeout etc), I
got caught out by the Watch timeout value using Milliseconds not seconds. 

Regards,
James
