### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ etcetera
 
 .Net client for [etcd](https://github.com/coreos/etcd) - a highly-available key value store for shared configuration and service discovery.
 
-#Getting started
+# Getting started
 
 ## Initialize
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
